### PR TITLE
We need to be able to specify the target component for a spool

### DIFF
--- a/component-3-patt-3-spool.js
+++ b/component-3-patt-3-spool.js
@@ -75,3 +75,19 @@ $cs.pattern.spool = $cs.trait({
     }
 });
 
+/*  split "[path:]name" into a component object and a spool name  */
+_cs.spoolParse = function (comp, spec) {
+    var info = {};
+
+    info.comp = comp;
+    info.name = spec;
+
+    var m = info.name.match(/^([^:]+):(.+)$/);
+    if (m !== null) {
+        info.comp = $cs(comp, m[1]);
+        info.name = m[2];
+    }
+
+    return info;
+}
+

--- a/component-3-patt-7-event.js
+++ b/component-3-patt-7-event.js
@@ -94,8 +94,10 @@ $cs.pattern.eventing = $cs.trait({
             this.__subscription[id] = params;
 
             /*  optionally spool reverse operation  */
-            if (params.spool !== null)
-                this.spool(params.spool, this, "unsubscribe", id);
+            if (params.spool !== null) {
+                var info = _cs.spoolParse(this, params.spool);
+                info.comp.spool(info.name, this, "unsubscribe", id);
+            }
 
             return id;
         },

--- a/component-3-patt-A-service.js
+++ b/component-3-patt-A-service.js
@@ -67,8 +67,10 @@ $cs.pattern.service = $cs.trait({
             });
 
             /*  optionally spool reverse operation  */
-            if (params.spool !== null)
-                this.spool(params.spool, this, "unregister", id);
+            if (params.spool !== null) {
+                var info = _cs.spoolParse(this, params.spool);
+                info.comp.spool(info.name, this, "unregister", id);
+            }
 
             return id;
         },

--- a/component-3-patt-C-socket.js
+++ b/component-3-patt-C-socket.js
@@ -102,8 +102,10 @@ $cs.pattern.socket = $cs.trait({
             _cs.plugger("plug", this, params.name, params.object);
 
             /*  optionally spool reverse operation  */
-            if (params.spool !== null)
-                this.spool(params.spool, this, "unplug", id);
+            if (params.spool !== null) {
+                var info = _cs.spoolParse(this, params.spool);
+                info.comp.spool(info.name, this, "unplug", id);
+            }
 
             return id;
         },

--- a/component-3-patt-D-hook.js
+++ b/component-3-patt-D-hook.js
@@ -34,8 +34,10 @@ $cs.pattern.hook = $cs.trait({
             });
 
             /*  optionally spool reverse operation  */
-            if (params.spool !== null)
-                this.spool(params.spool, this, "unlatch", id);
+            if (params.spool !== null) {
+                var info = _cs.spoolParse(this, params.spool);
+                info.comp.spool(info.name, this, "unlatch", id);
+            }
 
             return id;
         },

--- a/component-3-patt-G-model.js
+++ b/component-3-patt-G-model.js
@@ -258,8 +258,10 @@ $cs.pattern.model = $cs.trait({
             owner.property("ComponentJS:model:subscribers:" + params.operation, true);
 
             /*  optionally spool reverse operation  */
-            if (params.spool !== null)
-                this.spool(params.spool, this, "unobserve", id);
+            if (params.spool !== null) {
+                var info = _cs.spoolParse(this, params.spool);
+                info.comp.spool(info.name, this, "unobserve", id);
+            }
 
             /*  if requested, touch the model value once (for an initial observer run)  */
             if (params.touch)


### PR DESCRIPTION
In functions like observe, etc. it is possible to specify a spool, but only the name of the spool. Now we are also able to address the owner component of the spool (eg. spool: '[path:]name' instead of former spool: 'name')
