### PR TITLE
Automatically unspool life-cycle state named spools

### DIFF
--- a/component-3-patt-9-state.js
+++ b/component-3-patt-9-state.js
@@ -167,11 +167,6 @@ _cs.state_progression_run = function (comp, arg, _direction) {
             _cs.hook("ComponentJS:state-invalidate", "none", "states");
             _cs.hook("ComponentJS:state-change", "none");
 
-            /*  execute pending spooled actions  */
-            name = "ComponentJS:state:" + _cs.states[comp.__state].state + ":enter";
-            if (comp.spooled(name))
-                comp.unspool(name);
-
             /*  execute enter method  */
             if (_cs.state_method_call("enter", comp, enter) === false) {
                 /*  FULL STOP: state enter method rejected state transition  */
@@ -259,11 +254,6 @@ _cs.state_progression_run = function (comp, arg, _direction) {
             );
             _cs.hook("ComponentJS:state-invalidate", "none", "states");
             _cs.hook("ComponentJS:state-change", "none");
-
-            /*  execute pending spooled actions  */
-            name = "ComponentJS:state:" + state + ":leave";
-            if (comp.spooled(name))
-                comp.unspool(name);
 
             /*  execute leave method  */
             if (_cs.state_method_call("leave", comp, leave) === false) {


### PR DESCRIPTION
This patch checks the availability of a spool named like the leaving state, directly after the leave life-cycle method was performed. If a spool is found, then it is automatically unspooled.

Cleaned up the variable usage so that less object lookups are needed
