### PR TITLE
Prepend log messages instead of appending them

### DIFF
--- a/component.plugin.debugger-logbook.js
+++ b/component.plugin.debugger-logbook.js
@@ -32,13 +32,13 @@ _cs.dbg_log = function (msg) {
         "<span class=\"method\">$2</span>" +
         "<span class=\"arrow\">$3</span>"
     );
-    _cs.dbg_logbook +=
+    _cs.dbg_logbook =
         "<table class=\"line\">" +
             "<tr>" +
                 "<td class=\"num\">" + _cs.dbg_logline + ".</td>" +
                 "<td class=\"msg\">" + msg + "</td>" +
             "</tr>" +
-        "</table>";
+        "</table>" + _cs.dbg_logbook;
     _cs.dbg_state_invalidate("console");
     _cs.dbg_update();
 };

--- a/component.plugin.debugger-render.js
+++ b/component.plugin.debugger-render.js
@@ -92,9 +92,7 @@ _cs.dbg_update_once = function () {
     /*  update console information  */
     if (_cs.dbg_state_invalid.console) {
         _cs.jq(".dbg .console .text", _cs.dbg.document).html(_cs.dbg_logbook);
-        _cs.jq(".dbg .console", _cs.dbg.document).scrollTop(
-            _cs.jq(".dbg .console .text", _cs.dbg.document).height()
-        );
+        _cs.jq(".dbg .console", _cs.dbg.document).scrollTop(0);
         _cs.dbg_state_invalid.console = true;
     }
 


### PR DESCRIPTION
When the log messages are appended at the bottom of the log view, they get easily ignored by the developer.
So a better way would be to prepend them.
